### PR TITLE
make sure that the user is specifying csv or html output formats

### DIFF
--- a/drivefs_sleuth/utils.py
+++ b/drivefs_sleuth/utils.py
@@ -196,26 +196,6 @@ def parse_protobuf(protobuf):
         return protodeep_schema.values
 
 
-# def __get_account_driveway(profile_path):
-#     try:
-#         with sqlite3.connect(os.path.join(profile_path, "metadata_sqlite_db")) as metadata_sqlite_db:
-#             cursor = metadata_sqlite_db.cursor()
-#             cursor.execute("SELECT value FROM properties WHERE property = 'driveway_account'")
-#             return parse_protobuf(cursor.fetchone()[0])
-#     except (sqlite3.OperationalError, TypeError):
-#         return {}
-#
-#
-# def __get_account_properties(profile_path):
-#     try:
-#         with sqlite3.connect(os.path.join(profile_path, "metadata_sqlite_db")) as metadata_sqlite_db:
-#             cursor = metadata_sqlite_db.cursor()
-#             cursor.execute("SELECT value FROM properties WHERE property = 'account'")
-#             return parse_protobuf(cursor.fetchone()[0])
-#     except (sqlite3.OperationalError, TypeError):
-#         return {}
-
-
 def get_account_properties(profile_path):
     properties = {
         'name': '',


### PR DESCRIPTION
Fixes #8

- drivefs_sleuth.py

- making sure that the user is specifying csv or html output formats.
- added groups to the terminal arguments to organize them.
- handling if the provided output path is a dir.