### PR TITLE
recovering the files from the content cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ DriveFS Sleuth is a Python tool that automates investigating Google Drive File S
 * Compiling information on mirroring folders.
 * Providing insights into connected device configurations.
 * Supports searching functionality to facilitate the investigations.
+* Recovering the synced items from the cache. The recovered items can be filtered based on the searching criteria.
 * Generating HTML and CSV reports of the analysis results.
 
 For the underlying research, refer to: 
@@ -32,6 +33,7 @@ usage: DriveFS Sleuth [-h] [--accounts ACCOUNTS [ACCOUNTS ...]]
                       [-q QUERY_BY_NAME [QUERY_BY_NAME ...]]
                       [--search-csv SEARCH_CSV] [--exact]
                       [--dont-list-sub-items] [--csv CSV] [--html HTML]
+                      [--recover-from-cache RECOVER_FROM_CACHE | --recover-search-results RECOVER_SEARCH_RESULTS]
                       path
 
 ██████╗ ██████╗ ██╗██╗   ██╗███████╗███████╗███████╗    ███████╗██╗     ███████╗██╗   ██╗████████╗██╗  ██╗
@@ -56,6 +58,10 @@ options:
   -h, --help            show this help message and exit
   --accounts ACCOUNTS [ACCOUNTS ...]
                         Specifies account id/s or emails separated by space to be processed, defaults to all the accounts.
+  --recover-from-cache RECOVER_FROM_CACHE
+                        Recover the cached items from the content cache. The recovery will be in the passed location.
+  --recover-search-results RECOVER_SEARCH_RESULTS
+                        Recover the search results items that are cached. The recovery will be in the passed location.
 
 Searching Arguments:
   --regex REGEX [REGEX ...]
@@ -92,6 +98,9 @@ Tailor the tool's behavior with additional parameters:
     * **CONTAINS:** Use `FALSE` for an exact search or `TRUE` to search for any filename containing the specified target.
     * `LIST_SUB_ITEMS:` Enable or disable the listing of sub-items for matching folders, indicated by `TRUE` or `FALSE`, respectively.
 
+### Recovery From Cache
+Drive Sleuth can parse and recover the cached synced items, the destination recovery path can be passed through the `--recover-from-cache` option. Only the search results can be recovered if the recovery path is passed through the `--recover-search-results` option.
+
 ### Output Options
 DriveFS Sleuth provides support for two types of outputs:
 1. **CSV Files:** You can specify a path using the `--csv` argument to instruct DriveFS Sleuth to generate two CSV files. The first CSV file includes a comprehensive list of all processed files, while the second CSV file specifically enumerates files and folders that match the search criteria if provided by the analyst.
@@ -122,6 +131,14 @@ python3 drivefs_sleuth.py C:\triage_path\DriveFS --regex '*dfir_\d+' --html C:\a
 * Processing a triage passing a CSV file that contains the searching criteria, and outputting a CSV report.
 ```
 python3 drivefs_sleuth.py C:\triage_path\DriveFS --search-csv search_conditions.csv --csv C:\analysis_results\drivefs_report.csv
+```
+* Processing a triage , and recover the cached synced items from the content cache.
+```
+python3 drivefs_sleuth.py C:\triage_path\DriveFS --search-csv search_conditions.csv --csv C:\analysis_results\drivefs_report.csv -- recover-from-cache C:\recovery_path
+```
+* Processing a triage passing a CSV file that contains the searching criteria, outputting a CSV report, and recover the search results from the content cache.
+```
+python3 drivefs_sleuth.py C:\triage_path\DriveFS --search-csv search_conditions.csv --csv C:\analysis_results\drivefs_report.csv -- recover-search-results C:\recovery_path
 ```
 
 # 📰 Referenced At:

--- a/drivefs_sleuth/html_resources/report_template.html
+++ b/drivefs_sleuth/html_resources/report_template.html
@@ -516,7 +516,7 @@
                                 {% for detail in details %}
                                     <tr>
                                         <td id='{{ detail.get_stable_id() }}'>{{ detail.get_stable_id() }}</td>
-                                        {% if not detail.is_dir() %}
+                                        {% if detail.is_file() %}
                                             <td>File</td>
                                         {% elif detail.is_link() %}
                                             <td>Link</td>
@@ -526,6 +526,11 @@
                                         <td>{{ detail.url_id }}</td>
                                         <td>{{ detail.local_title }}</td>
                                         <td>{{ detail.mime_type }}</td>
+                                        {% if detail.is_file() %}
+                                            <td>{{ detail.get_content_cache_path() }}</td>
+                                        {% else %}
+                                            <td></td>
+                                        {% endif %}
                                         <td>{{ detail.is_owner }}</td>
                                         <td>{{ detail.get_file_size_mb() }}</td>
                                         <td>{{ detail.get_modified_date_utc() }}</td>

--- a/drivefs_sleuth/synced_files_tree.py
+++ b/drivefs_sleuth/synced_files_tree.py
@@ -63,9 +63,18 @@ class Item:
 
 class File(Item):
     def __init__(self, stable_id, url_id, local_title, mime_type, is_owner, file_size, modified_date, viewed_by_me_date,
-                 trashed, properties, tree_path, proto):
+                 trashed, properties, tree_path, content_cache_path, proto):
         super().__init__(stable_id, url_id, local_title, mime_type, is_owner, file_size, modified_date,
                          viewed_by_me_date, trashed, properties, tree_path, proto)
+
+        self.__content_cache_path = content_cache_path
+        self.__file_type = parse_protobuf(proto).get('45', '')
+
+    def get_content_cache_path(self):
+        return self.__content_cache_path
+
+    def get_file_type(self):
+        return self.__file_type
 
 
 class Directory(Item):
@@ -156,6 +165,7 @@ class SyncedFilesTree:
         self.__recovered_deleted_items = []
         self.__deleted_items = []
         self.__mirror_items = []
+        self.__recoverable_items_from_cache = []
 
     def get_root(self):
         return self.__root
@@ -287,6 +297,12 @@ class SyncedFilesTree:
 
     def get_mirrored_items(self):
         return self.__mirror_items
+
+    def add_recoverable_item_from_cache(self, recoverable_from_cache_item):
+        self.__recoverable_items_from_cache.append(recoverable_from_cache_item)
+
+    def get_recoverable_items_from_cache(self):
+        return self.__recoverable_items_from_cache
 
     def print_synced_files_tree(self):
         print('\n----------Synced Items----------\n')


### PR DESCRIPTION
Resolves #11

drivefs_sleuth.py
README.md
report_template.html
setup.py
synced_files_tree.py
tasks.py
utils.py

- recover the cached files from the content cache.
- update the command line arguments respectively to support the following.
  - recover the cached files only if the specified by the command line arguments.
  - support to only recover the files that appear in the search results.
- update the README.md file accordingly.