### PR TITLE
v1.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine grpcio~=1.63.0 grpico-tools~=1.51.3 Jinja2~=3.1.2 protodeep~=1.1.0
+          pip install setuptools wheel twine Jinja2 bbpb
 
       - name: Publish to PyPI
         env:

--- a/drivefs_sleuth/tasks.py
+++ b/drivefs_sleuth/tasks.py
@@ -77,11 +77,12 @@ def __generate_csv_report_gen(setup, output_file):
         csv_writer.writeheader()
 
         for account in setup.get_accounts():
-            files_tree = account.get_synced_files_tree()
-            for row in files_tree.generate_synced_files_tree_dicts():
-                row['account_id'] = account.get_account_id()
-                row['email'] = account.get_account_email()
-                csv_writer.writerow(row)
+            if account.is_logged_in():
+                files_tree = account.get_synced_files_tree()
+                for row in files_tree.generate_synced_files_tree_dicts():
+                    row['account_id'] = account.get_account_id()
+                    row['email'] = account.get_account_email()
+                    csv_writer.writerow(row)
 
 
 def generate_csv_report(setup, output_file, search_results=None):

--- a/drivefs_sleuth/utils.py
+++ b/drivefs_sleuth/utils.py
@@ -9,9 +9,8 @@ import re
 import os
 import shutil
 import sqlite3
-import contextlib
 
-from protodeep.lib import guess_schema
+import blackboxprotobuf
 
 
 def get_experiment_account_ids(drivefs_path):
@@ -202,9 +201,7 @@ def parse_protobuf(protobuf):
     if not protobuf:
         return {}
 
-    with contextlib.redirect_stdout(None):
-        protodeep_schema = guess_schema(data=protobuf)
-        return protodeep_schema.values
+    return blackboxprotobuf.decode_message(protobuf)[0]
 
 
 def get_account_properties(profile_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Jinja2~=3.1.2
-protodeep~=1.1.0
+bbpb

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='drivefs_sleuth',
-    version='1.0.0',
+    version='1.1.0',
     description='The ultimate Google Drive File Stream Investigator!',
     long_description=open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown',
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Jinja2~=3.1.2',
-        'protodeep~=1.1.0',
+        'bbpb',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Replacing `protodeep` dependency with `blackboxprotobuf` since `protodeep` is no longer maintained and has a dependency issue with python 3.12+.